### PR TITLE
fix byte-compile warning

### DIFF
--- a/pos-tip.el
+++ b/pos-tip.el
@@ -940,7 +940,7 @@ Note that this function is usable only in Emacs 23 for MS-Windows."
 	      (cons (frame-pixel-width)
 		    (+ (frame-pixel-height)
 		       (- (cdr offset) (car offset)))))
-      (if (interactive-p)
+      (if (called-interactively-p 'interactive)
 	  (message "%S" pos-tip-w32-saved-max-width-height))
       (unless keep-maximize
 	;; Restore frame


### PR DESCRIPTION
I got following error when I byte-compiled.

```
Entering directory `/home/syohei/tmp/gomi/pos-tip/'

In pos-tip-w32-max-width-height:
pos-tip.el:944:25:Warning: `interactive-p' is an obsolete function (as of
    23.2); use `called-interactively-p' instead.
```
