### PR TITLE
Use the tooltip face

### DIFF
--- a/pos-tip.el
+++ b/pos-tip.el
@@ -233,11 +233,6 @@
   :type 'integer
   :group 'pos-tip)
 
-(defcustom pos-tip-background-color (face-background 'tooltip)
-  "Default background color of pos-tip's tooltip."
-  :type 'string
-  :group 'pos-tip)
-
 (defcustom pos-tip-tab-width nil
   "Tab width used for `pos-tip-split-string' and `pos-tip-fill-string'
 to expand tab characters. nil means use default value of `tab-width'."

--- a/pos-tip.el
+++ b/pos-tip.el
@@ -233,6 +233,20 @@
   :type 'integer
   :group 'pos-tip)
 
+(defcustom pos-tip-foreground-color nil
+  "Default foreground color of pos-tip's tooltip.
+When `nil', look up the foreground color of the `tooltip' face."
+  :type '(choice (const :tag "Default" nil)
+                 string)
+  :group 'pos-tip)
+
+(defcustom pos-tip-background-color nil
+  "Default background color of pos-tip's tooltip.
+When `nil', look up the background color of the `tooltip' face."
+  :type '(choice (const :tag "Default" nil)
+                 string)
+  :group 'pos-tip)
+
 (defcustom pos-tip-tab-width nil
   "Tab width used for `pos-tip-split-string' and `pos-tip-fill-string'
 to expand tab characters. nil means use default value of `tab-width'."
@@ -529,20 +543,24 @@ in FRAME. Return new mouse position like (FRAME . (X . Y))."
   "Compute the foreground color to use for tooltip.
 
 TIP-COLOR is a face or a cons cell like (FOREGROUND-COLOR . BACKGROUND-COLOR).
-If it is nil, use the foreground color of the `tooltip' face."
+If it is nil, use `pos-tip-foreground-color'or the foreground color of the
+`tooltip' face."
   (or (and (facep tip-color)
            (face-attribute tip-color :foreground))
       (car-safe tip-color)
+      pos-tip-foreground-color
       (face-foreground 'tooltip)))
 
 (defun pos-tip-compute-background-color (tip-color)
   "Compute the background color to use for tooltip.
 
 TIP-COLOR is a face or a cons cell like (FOREGROUND-COLOR . BACKGROUND-COLOR).
-If it is nil, use the background color of the `tooltip' face."
+If it is nil, use `pos-tip-background-color' or the background color of the
+`tooltip' face."
   (or (and (facep tip-color)
            (face-attribute tip-color :background))
       (cdr-safe tip-color)
+      pos-tip-background-color
       (face-background 'tooltip)))
 
 (defun pos-tip-show-no-propertize
@@ -833,10 +851,11 @@ using frame's default font with TIP-COLOR.
 Return pixel position of tooltip relative to top left corner of frame as
 a cons cell like (X . Y).
 
-TIP-COLOR is a face or a cons cell like (FOREGROUND-COLOR . BACKGROUND-COLOR)
-used to specify *only* foreground-color and background-color of tooltip.
-If omitted, use the foreground and background color of the `tooltip' face
-instead.
+TIP-COLOR is a face or a cons cell like (FOREGROUND-COLOR .
+BACKGROUND-COLOR) used to specify *only* foreground-color and
+background-color of tooltip.  If omitted, use
+`pos-tip-foreground-color' and `pos-tip-background-color' or the
+foreground and background color of the `tooltip' face instead.
 
 Omitting POS and WINDOW means use current position and selected window,
 respectively.

--- a/pos-tip.el
+++ b/pos-tip.el
@@ -233,11 +233,6 @@
   :type 'integer
   :group 'pos-tip)
 
-(defcustom pos-tip-foreground-color (face-foreground 'tooltip)
-  "Default foreground color of pos-tip's tooltip."
-  :type 'string
-  :group 'pos-tip)
-
 (defcustom pos-tip-background-color (face-background 'tooltip)
   "Default background color of pos-tip's tooltip."
   :type 'string
@@ -539,21 +534,21 @@ in FRAME. Return new mouse position like (FRAME . (X . Y))."
   "Compute the foreground color to use for tooltip.
 
 TIP-COLOR is a face or a cons cell like (FOREGROUND-COLOR . BACKGROUND-COLOR).
-If it is nil, use `pos-tip-foreground-color'."
+If it is nil, use the foreground color of the `tooltip' face."
   (or (and (facep tip-color)
            (face-attribute tip-color :foreground))
       (car-safe tip-color)
-      pos-tip-foreground-color))
+      (face-foreground 'tooltip)))
 
 (defun pos-tip-compute-background-color (tip-color)
   "Compute the background color to use for tooltip.
 
 TIP-COLOR is a face or a cons cell like (FOREGROUND-COLOR . BACKGROUND-COLOR).
-If it is nil, use `pos-tip-background-color'."
+If it is nil, use the background color of the `tooltip' face."
   (or (and (facep tip-color)
            (face-attribute tip-color :background))
       (cdr-safe tip-color)
-      pos-tip-background-color))
+      (face-background 'tooltip)))
 
 (defun pos-tip-show-no-propertize
   (string &optional tip-color pos window timeout pixel-width pixel-height frame-coordinates dx dy)
@@ -845,7 +840,7 @@ a cons cell like (X . Y).
 
 TIP-COLOR is a face or a cons cell like (FOREGROUND-COLOR . BACKGROUND-COLOR)
 used to specify *only* foreground-color and background-color of tooltip.
-If omitted, use `pos-tip-foreground-color' and `pos-tip-background-color'
+If omitted, use the foreground and background color of the `tooltip' face
 instead.
 
 Omitting POS and WINDOW means use current position and selected window,


### PR DESCRIPTION
This is a bit embarassing.

After my last pull request I've run into a weird Emacs bug.  I'm using `emacsclient` which spawns an invisible, non-graphical server frame if it doesn't exist already, then a graphical one.  Initialization of the package happens at the former step, this leads to pos-tip initializing with `brightblue` and `brightblack` as colours which however aren't valid in graphical emacs instances. Debugging this led to a suspicious amount of Emacs crashes.  Making the theme set this variable wasn't helpful either.

I've therefore reconsidered my approach and went for something simpler.  Considering it's only themes customizing these values and every popular Emacs theme out there sets these colors to the same values as the tooltip colors, it makes not much sense keeping them separate.  That's why this pull request gets rid of the two customization variables and instead looks up the right colors from the tooltip face when needed.