### PR TITLE
Silence Emacs 29 compiler warnings

### DIFF
--- a/pos-tip.el
+++ b/pos-tip.el
@@ -270,7 +270,7 @@ coordinates can't be obtained by `pos-tip-compute-pixel-position'."
 
 (defun pos-tip-window-system (&optional frame)
   "The name of the window system that FRAME is displaying through.
-The value is a symbol---for instance, 'x' for X windows.
+The value is a symbol---for instance, `x' for X windows.
 The value is nil if Emacs is using a text-only terminal.
 
 FRAME defaults to the currently selected frame."
@@ -584,22 +584,22 @@ See `pos-tip-show' for details.
 Example:
 
 \(defface my-tooltip
-  '((t
+  \\='((t
      :background \"gray85\"
      :foreground \"black\"
      :inherit variable-pitch))
   \"Face for my tooltip.\")
 
 \(defface my-tooltip-highlight
-  '((t
+  \\='((t
      :background \"blue\"
      :foreground \"white\"
      :inherit my-tooltip))
   \"Face for my tooltip highlighted.\")
 
-\(let ((str (propertize \" foo \\n bar \\n baz \" 'face 'my-tooltip)))
-  (put-text-property 6 11 'face 'my-tooltip-highlight str)
-  (pos-tip-show-no-propertize str 'my-tooltip))"
+\(let ((str (propertize \" foo \\n bar \\n baz \" \\='face \\='my-tooltip)))
+  (put-text-property 6 11 \\='face \\='my-tooltip-highlight str)
+  (pos-tip-show-no-propertize str \\='my-tooltip))"
   (unless window
     (setq window (selected-window)))
   (let* ((frame (window-frame window))


### PR DESCRIPTION
* pos-tip.el (pos-tip-window-system, pos-tip-show-no-propertize):
Fix compiler warnings for unescaped single quotes in docstrings.