### PR TITLE
Properly specify version as 0.4.7

### DIFF
--- a/pos-tip.el
+++ b/pos-tip.el
@@ -6,7 +6,9 @@
 ;; Maintainer: S. Irie
 ;; Keywords: Tooltip
 
-(defconst pos-tip-version "0.4.6")
+;; Package-Version: 0.4.7
+
+(defconst pos-tip-version "0.4.7")
 
 ;; This program is free software; you can redistribute it and/or
 ;; modify it under the terms of the GNU General Public License as


### PR DESCRIPTION
Even though there have been changes since the 0.4.6 release many years ago, `pos-tip-version` is still set to 0.4.6, and the Package-Version is not specified in a way which package managers seem to understand.

This fixes an issue where elpaca fails to install packages which depend on `(pos-tip "0.4.6")` even though this version of the package is installed.

Fixes #8